### PR TITLE
omit empty META_INSTRUMENT event when track.instrument is nil

### DIFF
--- a/lib/midilib/io/seqwriter.rb
+++ b/lib/midilib/io/seqwriter.rb
@@ -112,10 +112,12 @@ module MIDI
       end
 
       def write_instrument(instrument)
-	event = MetaEvent.new(META_INSTRUMENT, instrument)
-	write_var_len(0)
-	data = event.data_as_bytes()
-	@bytes_written += write_bytes(data)
+        unless instrument.nil?
+          event = MetaEvent.new(META_INSTRUMENT, instrument)
+          write_var_len(0)
+          data = event.data_as_bytes()
+          @bytes_written += write_bytes(data)
+        end
       end
 
       def write_var_len(val)


### PR DESCRIPTION
Hi Jim,
I noticed midilib is generating unnecessary META_INSTRUMENT events. It was easy enough to avoid by checking if instrument is nil in seqwriter#write_instrument.

PS - sorry about the whitespace diff. Your tab settings seem odd from my perspective. I generally only use spaces and never tabs, to avoid unwanted whitespace diffs like this. BTW, did you know you can append ?w=1 to the URL in github's pull request screen, to ignore whitespace differences. Then you can see I simply added the "unless instrument.nil?" check.