### PR TITLE
Improve readability and add key signature to_code

### DIFF
--- a/lib/midilib/event.rb
+++ b/lib/midilib/event.rb
@@ -627,12 +627,36 @@ module MIDI
     # Returns the key signature as a text string.
     # Example: "key sig A flat major"
     def to_s
-      majorkeys = ['C flat', 'G flat', 'D flat', 'A flat', 'E flat', 'B flat', 'F',
-        'C', 'G', 'D', 'A', 'E', 'B', 'F#', 'C#']
-      minorkeys = ['a flat', 'e flat', 'b flat', 'f', 'c', 'g', 'd',
-        'a', 'e', 'b', 'f#', 'c#', 'g#', 'd#', 'a#']
       minor_key? ? "key sig #{minorkeys[sharpflat + 7]} minor" :
         "key sig #{majorkeys[sharpflat + 7]} major"
+    end
+    
+    # Returns the key signature as a code.
+    # Example: "Ab" for "key sig A flat major"
+    def to_code
+      minor_key? ? minorkey_codes[sharpflat + 7] :
+        majorkey_codes[sharpflat + 7]
+    end
+    
+    private
+    def majorkeys
+      @majorkeys ||= ['C flat', 'G flat', 'D flat', 'A flat', 'E flat', 'B flat', 'F',
+        'C', 'G', 'D', 'A', 'E', 'B', 'F#', 'C#']
+    end
+    
+    def minorkeys
+      @minorkeys ||= ['a flat', 'e flat', 'b flat', 'f', 'c', 'g', 'd',
+        'a', 'e', 'b', 'f#', 'c#', 'g#', 'd#', 'a#']
+    end
+
+    def majorkey_codes
+      @majorkeys_codes ||= ['Cb', 'Gb', 'Db', 'Ab', 'Eb', 'Bb', 'F',
+        'C', 'G', 'D', 'A', 'E', 'B', 'F#', 'C#']
+    end
+    
+    def minorkey_codes
+      @minorkeys_codes ||= ['Abm', 'Ebm', 'Bbm', 'Fm', 'Cm', 'Gm', 'Dm',
+        'Am', 'Em', 'Bm', 'F#m', 'C#m', 'G#m', 'D#m', 'A#m']
     end
   end
 


### PR DESCRIPTION
Break out minorkeys and majorkeys into separate methods for improved readability/re-usability and add support for displaying key signature as a code.