### PR TITLE
Feature/format 0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 html
 pkg
 .rbenv-version
+*.swp

--- a/lib/midilib/io/midifile.rb
+++ b/lib/midilib/io/midifile.rb
@@ -30,16 +30,16 @@ module MIDI
       # value is either the number of bytes needed (1 or 2) for a channel
       # message, or 0 if it's not a channel message.
       NUM_DATA_BYTES = [
-	0, 0, 0, 0, 0, 0, 0, 0, # 0x00 - 0x70
-	2, 2, 2, 2, 1, 1, 2, 0  # 0x80 - 0xf0
+        0, 0, 0, 0, 0, 0, 0, 0, # 0x00 - 0x70
+        2, 2, 2, 2, 1, 1, 2, 0  # 0x80 - 0xf0
       ]
 
-      attr_accessor  :curr_ticks	# Current time, from delta-time in MIDI file
+      attr_accessor  :curr_ticks  # Current time, from delta-time in MIDI file
       attr_accessor  :ticks_so_far # Number of delta-time ticks so far
       attr_accessor  :bytes_to_be_read # Counts number of bytes expected
 
-      attr_accessor  :no_merge	# true means continued sysex are not collapsed
-      attr_accessor  :skip_init	# true if initial garbage should be skipped
+      attr_accessor  :no_merge  # true means continued sysex are not collapsed
+      attr_accessor  :skip_init # true if initial garbage should be skipped
 
       # Raw data info
       attr_accessor  :raw_time_stamp_data
@@ -47,23 +47,23 @@ module MIDI
       attr_accessor  :raw_data
 
       def initialize
-	@no_merge = false
-	@skip_init = true
-	@io = nil
-	@bytes_to_be_read = 0
-	@msg_buf = nil
+        @no_merge = false
+        @skip_init = true
+        @io = nil
+        @bytes_to_be_read = 0
+        @msg_buf = nil
       end
 
       # The only public method. Each MIDI event in the file causes a
       # method to be called.
       def read_from(io)
-	error('must specify non-nil input stream') if io.nil?
-	@io = io
+        error('must specify non-nil input stream') if io.nil?
+        @io = io
 
-	ntrks = read_header()
-	error('No tracks!') if ntrks <= 0
+        ntrks = read_header()
+        error('No tracks!') if ntrks <= 0
 
-	ntrks.times { read_track() }
+        ntrks.times { read_track() }
       end
 
       # This default getc implementation tries to read a single byte
@@ -75,15 +75,15 @@ module MIDI
 
       # Return the next +n+ bytes from @io as an array.
       def get_bytes(n)
-	buf = []
-	n.times { buf << getc() }
-	buf
+        buf = []
+        n.times { buf << getc() }
+        buf
       end
 
       # The default error handler.
       def error(str)
-	loc = @io.tell() - 1
-	raise "#{self.class.name} error at byte #{loc} (0x#{'%02x' % loc}): #{str}"
+        loc = @io.tell() - 1
+        raise "#{self.class.name} error at byte #{loc} (0x#{'%02x' % loc}): #{str}"
       end
 
       # The rest of these are NOPs by default.
@@ -158,77 +158,77 @@ module MIDI
       # Read through 'MThd' or 'MTrk' header string. If skip is true, attempt
       # to skip initial trash. If there is an error, #error is called.
       def read_mt_header_string(bytes, skip)
-	b = []
-	bytes_to_read = 4
-	while true
-          data = get_bytes(bytes_to_read)
-          b += data
-          if b.length < 4
-            error("unexpected EOF while trying to read header string #{s}")
-          end
-
-          # See if we found the bytes we're looking for
-          return if b == bytes
-
-          if skip		# Try again with the next char
-            i = b[1..-1].index(bytes[0])
-            if i.nil?
-              b = []
-              bytes_to_read = 4
-            else
-              b = b[i..-1]
-              bytes_to_read = 4 - i
+          b = []
+          bytes_to_read = 4
+          while true
+            data = get_bytes(bytes_to_read)
+            b += data
+            if b.length < 4
+              error("unexpected EOF while trying to read header string #{s}")
             end
-          else
-            error("header string #{bytes.collect{|b| b.chr}.join} not found")
+
+            # See if we found the bytes we're looking for
+            return if b == bytes
+
+            if skip   # Try again with the next char
+              i = b[1..-1].index(bytes[0])
+              if i.nil?
+                b = []
+                bytes_to_read = 4
+              else
+                b = b[i..-1]
+                bytes_to_read = 4 - i
+              end
+              else
+                error("header string #{bytes.collect{|b| b.chr}.join} not found")
+            end
           end
-	end
       end
 
       # Read a header chunk.
       def read_header
-	@bytes_to_be_read = 0
-	read_mt_header_string(MThd_BYTE_ARRAY, @skip_init) # "MThd"
+        @bytes_to_be_read = 0
+        read_mt_header_string(MThd_BYTE_ARRAY, @skip_init) # "MThd"
 
-	@bytes_to_be_read = read32()
-	format = read16()
-	ntrks = read16()
-	division = read16()
+        @bytes_to_be_read = read32()
+        format = read16()
+        ntrks = read16()
+        division = read16()
 
-	header(format, ntrks, division)
+        header(format, ntrks, division)
 
-	# Flush any extra stuff, in case the length of the header is not 6
-	if @bytes_to_be_read > 0
-          get_bytes(@bytes_to_be_read)
-          @bytes_to_be_read = 0
-	end
+        # Flush any extra stuff, in case the length of the header is not 6
+        if @bytes_to_be_read > 0
+                get_bytes(@bytes_to_be_read)
+                @bytes_to_be_read = 0
+        end
 
-	return ntrks
+        return ntrks
       end
 
-      # Read a track chunk.
+            # Read a track chunk.
       def read_track
-	c = c1 = type = needed = 0
-	sysex_continue = false	# True if last msg was unfinished
-	running = false		# True when running status used
-	status = 0		# (Possibly running) status byte
+        c = c1 = type = needed = 0
+        sysex_continue = false  # True if last msg was unfinished
+        running = false   # True when running status used
+        status = 0    # (Possibly running) status byte
 
-	@bytes_to_be_read = 0
-	read_mt_header_string(MTrk_BYTE_ARRAY, false)
+        @bytes_to_be_read = 0
+        read_mt_header_string(MTrk_BYTE_ARRAY, false)
 
-	@bytes_to_be_read = read32()
-	@curr_ticks = @ticks_so_far = 0
+        @bytes_to_be_read = read32()
+        @curr_ticks = @ticks_so_far = 0
 
-	start_track()
+        start_track()
 
-	while @bytes_to_be_read > 0
+        while @bytes_to_be_read > 0
           @curr_ticks = read_var_len() # Delta time
           @ticks_so_far += @curr_ticks
 
           # Copy raw var num data into raw time stamp data
           @raw_time_stamp_data = @raw_var_num_data.dup()
 
-          c = getc()		# Read first byte
+          c = getc()    # Read first byte
 
           if sysex_continue && c != EOX
             error("didn't find expected continuation of a sysex")
@@ -244,7 +244,7 @@ module MIDI
 
           needed = NUM_DATA_BYTES[(status >> 4) & 0x0f]
 
-          if needed.nonzero?	# i.e., is it a channel message?
+          if needed.nonzero?  # i.e., is it a channel message?
             c1 = running ? c : (getc() & 0x7f)
 
             # The "& 0x7f" here may seem unnecessary, but I've seen
@@ -257,12 +257,12 @@ module MIDI
           end
 
           case c
-          when META_EVENT	# Meta event
+          when META_EVENT # Meta event
             type = getc()
             msg_init()
             msg_read(read_var_len())
             meta_event(type)
-          when SYSEX		# Start of system exclusive
+          when SYSEX    # Start of system exclusive
             msg_init()
             msg_add(SYSEX)
             c = msg_read(read_var_len())
@@ -272,7 +272,7 @@ module MIDI
             else
               sysex_continue = true
             end
-          when EOX		# Sysex continuation or arbitrary stuff
+          when EOX    # Sysex continuation or arbitrary stuff
             msg_init() if !sysex_continue
             c = msg_read(read_var_len())
 
@@ -285,114 +285,114 @@ module MIDI
           else
             bad_byte(c)
           end
-	end
-	end_track()
+        end
+        end_track()
       end
 
       # Handle an unexpected byte.
       def bad_byte(c)
-	error(sprintf("unexpected byte: 0x%02x", c))
+        error(sprintf("unexpected byte: 0x%02x", c))
       end
 
       # Handle a meta event.
       def meta_event(type)
-	m = msg()		# Copy of internal message buffer
+        m = msg()   # Copy of internal message buffer
 
-	# Create raw data array
-	@raw_data = []
-	@raw_data << META_EVENT
-	@raw_data << type
-	@raw_data << @raw_var_num_data
-	@raw_data << m
-	@raw_data.flatten!
+        # Create raw data array
+        @raw_data = []
+        @raw_data << META_EVENT
+        @raw_data << type
+        @raw_data << @raw_var_num_data
+        @raw_data << m
+        @raw_data.flatten!
 
-	case type
-	when META_SEQ_NUM
-          sequence_number((m[0] << 8) + m[1])
-	when META_TEXT, META_COPYRIGHT, META_SEQ_NAME, META_INSTRUMENT,
-          META_LYRIC, META_MARKER, META_CUE, 0x08, 0x09, 0x0a,
-          0x0b, 0x0c, 0x0d, 0x0e, 0x0f
-          text(type, m)
-	when META_TRACK_END
-          eot()
-	when META_SET_TEMPO
-          tempo((m[0] << 16) + (m[1] << 8) + m[2])
-	when META_SMPTE
-          smpte(m[0], m[1], m[2], m[3], m[4])
-	when META_TIME_SIG
-          time_signature(m[0], m[1], m[2], m[3])
-	when META_KEY_SIG
-          key_signature(m[0], m[1] == 0 ? false : true)
-	when META_SEQ_SPECIF
-          sequencer_specific(type, m)
-	else
-          meta_misc(type, m)
-	end
+        case type
+        when META_SEQ_NUM
+                sequence_number((m[0] << 8) + m[1])
+        when META_TEXT, META_COPYRIGHT, META_SEQ_NAME, META_INSTRUMENT,
+                META_LYRIC, META_MARKER, META_CUE, 0x08, 0x09, 0x0a,
+                0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+                text(type, m)
+        when META_TRACK_END
+                eot()
+        when META_SET_TEMPO
+                tempo((m[0] << 16) + (m[1] << 8) + m[2])
+        when META_SMPTE
+                smpte(m[0], m[1], m[2], m[3], m[4])
+        when META_TIME_SIG
+                time_signature(m[0], m[1], m[2], m[3])
+        when META_KEY_SIG
+                key_signature(m[0], m[1] == 0 ? false : true)
+        when META_SEQ_SPECIF
+                sequencer_specific(type, m)
+        else
+                meta_misc(type, m)
+        end
       end
 
       # Handle a channel message (note on, note off, etc.)
       def chan_message(running, status, c1, c2)
-	@raw_data = []
-	@raw_data << status unless running
-	@raw_data << c1
-	@raw_data << c2
+        @raw_data = []
+        @raw_data << status unless running
+        @raw_data << c1
+        @raw_data << c2
 
-	chan = status & 0x0f
+        chan = status & 0x0f
 
-	case (status & 0xf0)
-	when NOTE_OFF
-          note_off(chan, c1, c2)
-	when NOTE_ON
-          note_on(chan, c1, c2)
-	when POLY_PRESSURE
-          pressure(chan, c1, c2)
-	when CONTROLLER
-          controller(chan, c1, c2)
-	when PITCH_BEND
-          pitch_bend(chan, c1, c2)
-	when PROGRAM_CHANGE
-          program(chan, c1)
-	when CHANNEL_PRESSURE
-          chan_pressure(chan, c1)
-	else
-          error("illegal chan message 0x#{'%02x' % (status & 0xf0)}\n")
-	end
+        case (status & 0xf0)
+        when NOTE_OFF
+                note_off(chan, c1, c2)
+        when NOTE_ON
+                note_on(chan, c1, c2)
+        when POLY_PRESSURE
+                pressure(chan, c1, c2)
+        when CONTROLLER
+                controller(chan, c1, c2)
+        when PITCH_BEND
+                pitch_bend(chan, c1, c2)
+        when PROGRAM_CHANGE
+                program(chan, c1)
+        when CHANNEL_PRESSURE
+                chan_pressure(chan, c1)
+        else
+                error("illegal chan message 0x#{'%02x' % (status & 0xf0)}\n")
+        end
       end
 
       # Copy message into raw data array, then call sysex().
       def handle_sysex(msg)
-	@raw_data = msg.dup()
-	sysex(msg)
+        @raw_data = msg.dup()
+        sysex(msg)
       end
 
       # Copy message into raw data array, then call arbitrary().
       def handle_arbitrary(msg)
-	@raw_data = msg.dup()
-	arbitrary(msg)
+        @raw_data = msg.dup()
+        arbitrary(msg)
       end
 
       # Read and return a sixteen bit value.
       def read16
-	val = (getc() << 8) + getc()
-	val = -(val & 0x7fff) if (val & 0x8000).nonzero?
-	return val
+        val = (getc() << 8) + getc()
+        val = -(val & 0x7fff) if (val & 0x8000).nonzero?
+        return val
       end
 
       # Read and return a 32-bit value.
       def read32
-	val = (getc() << 24) + (getc() << 16) + (getc() << 8) +
-          getc()
-	val = -(val & 0x7fffffff) if (val & 0x80000000).nonzero?
-	return val
+        val = (getc() << 24) + (getc() << 16) + (getc() << 8) +
+                getc()
+        val = -(val & 0x7fffffff) if (val & 0x80000000).nonzero?
+        return val
       end
 
       # Read a varlen value.
       def read_var_len
-	@raw_var_num_data = []
-	c = getc()
-	@raw_var_num_data << c
-	val = c
-	if (val & 0x80).nonzero?
+        @raw_var_num_data = []
+        c = getc()
+        @raw_var_num_data << c
+        val = c
+        if (val & 0x80).nonzero?
           val &= 0x7f
           while true
             c = getc()
@@ -400,64 +400,64 @@ module MIDI
             val = (val << 7) + (c & 0x7f)
             break if (c & 0x80).zero?
           end
-	end
-	return val
+        end
+        return val
       end
 
       # Write a sixteen-bit value.
       def write16(val)
-	val = (-val) | 0x8000 if val < 0
-	putc((val >> 8) & 0xff)
-	putc(val & 0xff)
+        val = (-val) | 0x8000 if val < 0
+        putc((val >> 8) & 0xff)
+        putc(val & 0xff)
       end
 
       # Write a 32-bit value.
       def write32(val)
-	val = (-val) | 0x80000000 if val < 0
-	putc((val >> 24) & 0xff)
-	putc((val >> 16) & 0xff)
-	putc((val >> 8) & 0xff)
-	putc(val & 0xff)
+        val = (-val) | 0x80000000 if val < 0
+        putc((val >> 24) & 0xff)
+        putc((val >> 16) & 0xff)
+        putc((val >> 8) & 0xff)
+        putc(val & 0xff)
       end
 
       # Write a variable length value.
       def write_var_len(val)
-	if val.zero?
-          putc(0)
-          return
-	end
+        if val.zero?
+                putc(0)
+                return
+        end
 
-	buf = []
+        buf = []
 
-	buf << (val & 0x7f)
-	while (value >>= 7) > 0
-          buf << (val & 0x7f) | 0x80
-	end
+        buf << (val & 0x7f)
+        while (value >>= 7) > 0
+                buf << (val & 0x7f) | 0x80
+        end
 
-	buf.reverse.each { |b| putc(b) }
+        buf.reverse.each { |b| putc(b) }
       end
 
       # Add a byte to the current message buffer.
       def msg_add(c)
-	@msg_buf << c
+        @msg_buf << c
       end
 
       # Read and add a number of bytes to the message buffer. Return
       # the last byte (so we can see if it's an EOX or not).
       def msg_read(n_bytes)
-	@msg_buf += get_bytes(n_bytes)
-	@msg_buf.flatten!
-	return @msg_buf[-1]
+        @msg_buf += get_bytes(n_bytes)
+        @msg_buf.flatten!
+        return @msg_buf[-1]
       end
 
       # Initialize the internal message buffer.
       def msg_init
-	@msg_buf = []
+        @msg_buf = []
       end
 
       # Return a copy of the internal message buffer.
       def msg
-	return @msg_buf.dup()
+        return @msg_buf.dup()
       end
 
     end

--- a/lib/midilib/io/seqwriter.rb
+++ b/lib/midilib/io/seqwriter.rb
@@ -29,7 +29,7 @@ module MIDI
       def write_header
           @io.print 'MThd'
           write32(6)
-          write16(1)    # Ignore sequence format; write as format 1
+          write16(@seq.format)
           write16(@seq.tracks.length)
           write16(@seq.ppqn)
       end

--- a/lib/midilib/io/seqwriter.rb
+++ b/lib/midilib/io/seqwriter.rb
@@ -10,105 +10,105 @@ module MIDI
     class SeqWriter
 
       def initialize(seq, proc = nil) # :yields: num_tracks, index
-	@seq = seq
-	@update_block = block_given?() ? Proc.new() : proc
+          @seq = seq
+          @update_block = block_given?() ? Proc.new() : proc
       end
 
       # Writes a MIDI format 1 file.
       def write_to(io)
-	@io = io
-	@bytes_written = 0
-	write_header()
-	@update_block.call(nil, @seq.tracks.length, 0) if @update_block
-	@seq.tracks.each_with_index do |track, i|
-          write_track(track)
-          @update_block.call(track, @seq.tracks.length, i) if @update_block
-	end
+          @io = io
+          @bytes_written = 0
+          write_header()
+          @update_block.call(nil, @seq.tracks.length, 0) if @update_block
+          @seq.tracks.each_with_index do |track, i|
+                  write_track(track)
+                  @update_block.call(track, @seq.tracks.length, i) if @update_block
+          end
       end
 
       def write_header
-	@io.print 'MThd'
-	write32(6)
-	write16(1)		# Ignore sequence format; write as format 1
-	write16(@seq.tracks.length)
-	write16(@seq.ppqn)
+          @io.print 'MThd'
+          write32(6)
+          write16(1)    # Ignore sequence format; write as format 1
+          write16(@seq.tracks.length)
+          write16(@seq.ppqn)
       end
 
       def write_track(track)
-	@io.print 'MTrk'
-	track_size_file_pos = @io.tell()
-	write32(0)		# Dummy byte count; overwritten later
-	@bytes_written = 0	# Reset after previous write
+          @io.print 'MTrk'
+          track_size_file_pos = @io.tell()
+          write32(0)    # Dummy byte count; overwritten later
+          @bytes_written = 0  # Reset after previous write
 
-	write_instrument(track.instrument)
+          write_instrument(track.instrument)
 
-	prev_event = nil
-	prev_status = 0
-	track.events.each do |event|
-          if !event.kind_of?(Realtime)
-            write_var_len(event.delta_time)
+          prev_event = nil
+          prev_status = 0
+          track.events.each do |event|
+                  if !event.kind_of?(Realtime)
+                    write_var_len(event.delta_time)
+                  end
+
+                  data = event.data_as_bytes()
+                  status = data[0] # status byte plus channel number, if any
+
+                  # running status byte
+                  status = possibly_munge_due_to_running_status_byte(data, prev_status)
+
+                  @bytes_written += write_bytes(data)
+
+                  prev_event = event
+                  prev_status = status
           end
 
-          data = event.data_as_bytes()
-          status = data[0] # status byte plus channel number, if any
+          # Write track end event.
+          event = MetaEvent.new(META_TRACK_END)
+          write_var_len(0)
+          @bytes_written += write_bytes(event.data_as_bytes())
 
-          # running status byte
-          status = possibly_munge_due_to_running_status_byte(data, prev_status)
-
-          @bytes_written += write_bytes(data)
-
-          prev_event = event
-          prev_status = status
-	end
-
-	# Write track end event.
-	event = MetaEvent.new(META_TRACK_END)
-	write_var_len(0)
-	@bytes_written += write_bytes(event.data_as_bytes())
-
-	# Go back to beginning of track data and write number of bytes,
-	# then come back here to end of file.
-	@io.seek(track_size_file_pos)
-	write32(@bytes_written)
-	@io.seek(0, ::IO::SEEK_END)
+          # Go back to beginning of track data and write number of bytes,
+          # then come back here to end of file.
+          @io.seek(track_size_file_pos)
+          write32(@bytes_written)
+          @io.seek(0, ::IO::SEEK_END)
       end
 
       # If we can use a running status byte, delete the status byte from
       # the given data. Return the status to remember for next time as the
       # running status byte for this event.
       def possibly_munge_due_to_running_status_byte(data, prev_status)
-	status = data[0]
-	return status if status >= 0xf0 || prev_status >= 0xf0
+          status = data[0]
+          return status if status >= 0xf0 || prev_status >= 0xf0
 
-	chan = (status & 0x0f)
-	return status if chan != (prev_status & 0x0f)
+          chan = (status & 0x0f)
+          return status if chan != (prev_status & 0x0f)
 
-	status = (status & 0xf0)
-	prev_status = (prev_status & 0xf0)
+          status = (status & 0xf0)
+          prev_status = (prev_status & 0xf0)
 
-	# Both events are on the same channel. If the two status bytes are
-	# exactly the same, the rest is trivial. If it's note on/note off,
-	# we can combine those further.
-	if status == prev_status
-          data[0,1] = []	# delete status byte from data
-          return status + chan
-	elsif status == NOTE_OFF && data[2] == 64
-          # If we see a note off and the velocity is 64, we can store
-          # a note on with a velocity of 0. If the velocity isn't 64
-          # then storing a note on would be bad because the would be
-          # changed to 64 when reading the file back in.
-          data[2] = 0		# set vel to 0; do before possible shrinking
-          status = NOTE_ON + chan
-          if prev_status == NOTE_ON
-            data[0,1] = []	# delete status byte
+          # Both events are on the same channel. If the two status bytes are
+          # exactly the same, the rest is trivial. If it's note on/note off,
+          # we can combine those further.
+          if status == prev_status
+                  data[0,1] = []  # delete status byte from data
+                  return status + chan
+          elsif status == NOTE_OFF && data[2] == 64
+                  # If we see a note off and the velocity is 64, we can store
+                  # a note on with a velocity of 0. If the velocity isn't 64
+                  # then storing a note on would be bad because the would be
+                  # changed to 64 when reading the file back in.
+                  data[2] = 0   # set vel to 0; do before possible shrinking
+                  status = NOTE_ON + chan
+                  if prev_status == NOTE_ON
+                    data[0,1] = []  # delete status byte
+                  else
+                    data[0] = status
+                  end
+                  return status
           else
-            data[0] = status
+                  # Can't compress data
+                  return status + chan
           end
-          return status
-	else
-          # Can't compress data
-          return status + chan
-	end
       end
 
       def write_instrument(instrument)
@@ -121,32 +121,32 @@ module MIDI
       end
 
       def write_var_len(val)
-	buffer = Utils.as_var_len(val)
-	@bytes_written += write_bytes(buffer)
+          buffer = Utils.as_var_len(val)
+          @bytes_written += write_bytes(buffer)
       end
 
       def write16(val)
-	val = (-val | 0x8000) if val < 0
+          val = (-val | 0x8000) if val < 0
 
-	buffer = []
-	@io.putc((val >> 8) & 0xff)
-	@io.putc(val & 0xff)
-	@bytes_written += 2
+          buffer = []
+          @io.putc((val >> 8) & 0xff)
+          @io.putc(val & 0xff)
+          @bytes_written += 2
       end
 
       def write32(val)
-	val = (-val | 0x80000000) if val < 0
+          val = (-val | 0x80000000) if val < 0
 
-	@io.putc((val >> 24) & 0xff)
-	@io.putc((val >> 16) & 0xff)
-	@io.putc((val >> 8) & 0xff)
-	@io.putc(val & 0xff)
-	@bytes_written += 4
+          @io.putc((val >> 24) & 0xff)
+          @io.putc((val >> 16) & 0xff)
+          @io.putc((val >> 8) & 0xff)
+          @io.putc(val & 0xff)
+          @bytes_written += 4
       end
 
       def write_bytes(bytes)
-	bytes.each { |b| @io.putc(b) }
-	bytes.length
+          bytes.each { |b| @io.putc(b) }
+          bytes.length
       end
     end
 

--- a/lib/midilib/sequence.rb
+++ b/lib/midilib/sequence.rb
@@ -21,8 +21,37 @@ module MIDI
     end
   end
 
+  class Format1Sequence
+    def initialize()
+      @seq = Sequence.new(1)
+    end
+
+    def add_track()
+      track = Track.new(@seq)
+      @seq.tracks.append(track)
+      track
+    end
+
+    def track(n)
+      @seq.tracks[n]
+    end
+
+    def write(io, proc = nil)	# :yields: track, num_tracks, index
+      @seq.write(io, proc)
+    end
+  end
+
   # A MIDI::Sequence contains MIDI::Track objects.
   class Sequence
+
+    def Sequence.from_format(format)
+      if format == 0
+        return Format0Sequence.new()
+      elsif format == 1
+        return Format1Sequence
+      end
+      raise ArgumentError, "format #{format} not supported"
+    end
 
     include Enumerable
 

--- a/lib/midilib/sequence.rb
+++ b/lib/midilib/sequence.rb
@@ -42,7 +42,7 @@ module MIDI
     # MIDI::IO::SeqWriter. You can change this at any time.
     attr_accessor :writer_class
 
-    def initialize
+    def initialize(format = 1)
       @tracks = Array.new()
       @ppqn = 480
 
@@ -51,6 +51,10 @@ module MIDI
       @denom = 2
       @clocks = 24    # Bug fix  Nov 11, 2007 - this is not the same as ppqn!
       @qnotes = 8
+      if format > 2 or format < 0
+          raise ArgumentError, 'format should be 0, 1 or 2'
+      end
+      @format = format
 
       @reader_class = IO::SeqReader
       @writer_class = IO::SeqWriter

--- a/lib/midilib/sequence.rb
+++ b/lib/midilib/sequence.rb
@@ -4,6 +4,23 @@ require 'midilib/measure.rb'
 
 module MIDI
 
+  class Format0Sequence
+    attr_accessor :track, :seq
+    def initialize()
+      @seq = Sequence.new(0)
+      @track = MIDI::Track.new(@seq)
+      @seq.tracks << @track
+    end
+
+    def track
+      @seq.tracks[0]
+    end
+
+    def write(io, proc = nil)	# :yields: track, num_tracks, index
+      @seq.write(io, proc)
+    end
+  end
+
   # A MIDI::Sequence contains MIDI::Track objects.
   class Sequence
 

--- a/test/test_format_0.rb
+++ b/test/test_format_0.rb
@@ -1,0 +1,31 @@
+# Start looking for MIDI classes in the directory above this one.
+# This forces us to use the local copy of MIDI, even if there is
+# a previously installed version out there somewhere.
+$LOAD_PATH[0, 0] = File.join(File.dirname(__FILE__), '..', 'lib')
+
+require 'test/unit'
+require 'midilib'
+
+class Format0Tester < Test::Unit::TestCase
+
+  def setup
+    @seq = MIDI::Format0Sequence.new()
+    @seq.track.events << MIDI::NoteOn.new(0, 64, 127, 0)
+    @seq.track.events << MIDI::NoteOff.new(0, 64, 127, 1)
+    @seq.track.recalc_times
+    @path = '/tmp/midilib-test.mid'
+    File.open(@path, 'wb') { |file|
+      @seq.write(file)
+    }
+  end
+
+  def test_can_read_format_0
+    seq = MIDI::Sequence.new()
+    File.open(@path, 'rb') {|file|
+      seq.read(file)
+    }
+    assert_equal(1, seq.tracks.length)
+    assert_equal(2, seq.tracks[0].events.length)
+  end
+end
+

--- a/test/test_format_0_sequence.rb
+++ b/test/test_format_0_sequence.rb
@@ -1,0 +1,23 @@
+# Start looking for MIDI classes in the directory above this one.
+# This forces us to use the local copy of MIDI, even if there is
+# a previously installed version out there somewhere.
+$LOAD_PATH[0, 0] = File.join(File.dirname(__FILE__), '..', 'lib')
+
+require 'test/unit'
+require 'midilib'
+
+class Format0SequenceTester < Test::Unit::TestCase
+
+  def setup
+    @seq = MIDI::Format0Sequence.new()
+    3.times { @seq.track.events << MIDI::NoteOn.new(0, 64, 64, 100) }
+    @seq.track.recalc_times
+  end
+
+  def test_basics
+    assert_equal(0, @seq.seq.format)
+    assert_equal(120, @seq.seq.beats_per_minute)
+    assert_equal(MIDI::Track::UNNAMED, @seq.seq.name)
+    assert_equal(MIDI::Sequence::DEFAULT_TEMPO, @seq.seq.bpm)
+  end
+end

--- a/test/test_sequence.rb
+++ b/test/test_sequence.rb
@@ -17,10 +17,25 @@ class SequenceTester < Test::Unit::TestCase
   end
 
   def test_basics
+    assert_equal(1, @seq.format)
     assert_equal(120, @seq.beats_per_minute)
     assert_equal(1, @seq.tracks.length)
     assert_equal(MIDI::Track::UNNAMED, @seq.name)
     assert_equal(MIDI::Sequence::DEFAULT_TEMPO, @seq.bpm)
+  end
+
+  def test_setting_format
+    assert_equal(MIDI::Sequence.new(0).format, 0)
+  end
+
+  def test_setting_an_invalid_format
+    assert_raise ArgumentError, 'format should be 0, 1 or 2' do
+        MIDI::Sequence.new(3)
+    end
+
+    assert_raise ArgumentError, 'format should be 0, 1 or 2' do
+        MIDI::Sequence.new(-1)
+    end
   end
 
   def test_pulses_to_seconds

--- a/test/test_seqwriter.rb
+++ b/test/test_seqwriter.rb
@@ -1,0 +1,44 @@
+# Start looking for MIDI classes in the directory above this one.
+# This forces us to use the local copy of MIDI, even if there is
+# a previously installed version out there somewhere.
+$LOAD_PATH[0, 0] = File.join(File.dirname(__FILE__), '..', 'lib')
+# Add current directory so we can find event_equality
+$LOAD_PATH[0, 0] = File.dirname(__FILE__)
+
+require 'test/unit'
+require 'midilib'
+require 'stringio'
+
+class TestableSeqWriter < MIDI::IO::SeqWriter
+  def initialize(seq, io)
+    @bytes_written = 0
+    @io = io
+    super(seq)
+  end
+end
+
+class SeqWriterTests < Test::Unit::TestCase
+
+  def test_writes_header()
+    io = StringIO.new()
+    version = 0
+    seq = MIDI::Sequence.new(version)
+    TestableSeqWriter.new(seq, io).write_header
+
+    io.rewind()
+    MIDI::IO::MIDIFile.new()
+    header = ""
+    (0..3).to_a.each{|_|
+      header += io.getc()
+    }
+    assert_equal(header, 'MThd')
+
+    @m = MIDI::IO::MIDIFile.new
+    @m.io = io
+    @m.msg_init
+    assert_equal(@m.read32(), 6)
+    assert_equal(@m.read16(), 0)
+
+  end
+end
+


### PR DESCRIPTION
I wanted to get this in early before I went too far down the wrong path. The aim of this is to provide basic support for writing MIDI format 0 files. What are your thoughts on this approach?

All I've really done is:

* Allow you to set the version in the `Sequence` constructor (defaulting to 1 for backwards compatibility)
* Create a `Format0Sequence` class which auto creates a single track for you and wraps `Sequence`.
* Change `SeqWriter` to read the version from the sequence (rather than hardcoding 1)
* Re-indent seqwriter and midifile as the has a mix of tabs and spaces and weird indentation
* Added a factory method on Sequence to create a sequence of the right format. The tracks array is private, so that you can't add new tracks in the format 0 version.

So the new way to create a Sequence would be something like:

```ruby
seq = Sequence.from_format(0)
seq.track.events << NoteOn(...)
```

and

```ruby
seq = Sequence.from_format(1)
track = seq.add_track
track.events << NoteOn(...)
```