### PR TITLE
Proposal to keep the delta time of META_SEQ_NAME and META_COPYRIGHT event

### DIFF
--- a/lib/midilib/io/seqreader.rb
+++ b/lib/midilib/io/seqreader.rb
@@ -145,10 +145,8 @@ module MIDI
 
       def text(type, msg)
 	case type
-        when META_TEXT, META_LYRIC, META_CUE
+        when META_TEXT, META_LYRIC, META_CUE, META_SEQ_NAME, META_COPYRIGHT
           @track.events << MetaEvent.new(type, msg, @curr_ticks)
-	when META_SEQ_NAME, META_COPYRIGHT
-          @track.events << MetaEvent.new(type, msg, 0)
 	when META_INSTRUMENT
           @track.instrument = msg
 	when META_MARKER


### PR DESCRIPTION
## Summary

The proposal to keep the delta time of META_SEQ_NAME and META_COPYRIGHT event instead of resetting it to zero. This is for some weird (?) MIDI files.

## How to Reproduce Issue

1. Copy [a sample MIDI file](https://www.mutopiaproject.org/ftp/BachJS/BWV846/wtk1-prelude1/wtk1-prelude1.mid) with midilib using the following code.
2. Play both of the original `wtk1-prelude1.mid'` and the output `output.mid`. So you'll find the obvious error.

```rb
require "midilib"

def read_midifile(infile)
    MIDI::Sequence.new().tap do |seq|
        File.open(infile, 'rb') { |file|
            seq.read(file)
        }
    end
end

def write_midifile(outfile, seq)
    File.open(outfile, 'wb') { |file|
        seq.write(file)
    }
end

# Download a midi file from Mutopia project
system "curl -O 'https://www.mutopiaproject.org/ftp/BachJS/BWV846/wtk1-prelude1/wtk1-prelude1.mid'"

# Just copy the SMF data as is using midilib.
write_midifile('output.mid', read_midifile('wtk1-prelude1.mid'))
```

## Detail

The above sample MIDI file contains three tracks. In one of the tracks, the time of the first note-on is located by the delta time of META_SEQ_NAME event that precedes it.

However, midilib resets the delta time of META_SEQ_NAME event to zero, so the position of the note-on event is set to zero.

I don't understand the MIDI specification related to this issue, but if this fix is appropriate, midilib will be able to handle such weird(?) MIDI files.
