### PR TITLE
Keep unusual note off event in input

### DIFF
--- a/lib/midilib/io/seqreader.rb
+++ b/lib/midilib/io/seqreader.rb
@@ -81,16 +81,29 @@ module MIDI
       def note_off(chan, note, vel)
         # Find note on, create note off, connect the two, and remove
         # note on from pending list.
+
+        corresp_note_on = nil
+
         @pending.each_with_index do |on, i|
           next unless on.note == note && on.channel == chan
 
-          make_note_off(on, vel)
           @pending.delete_at(i)
-          return
+          corresp_note_on = on
+          break
         end
-        if $DEBUG
-          warn "note off with no earlier note on (ch #{chan}, note" +
-               " #{note}, vel #{vel})"
+
+        if corresp_note_on
+          make_note_off(corresp_note_on, vel)
+        else
+          # When a corresponding note on is missing,
+          # keep note off as input with lefting on/off attr to nil.
+          off = NoteOff.new(chan, note, vel, @curr_ticks)
+          @track.events << off
+
+          if $DEBUG
+            warn "note off with no earlier note on (ch #{chan}, note" +
+              " #{note}, vel #{vel})"
+          end
         end
       end
 


### PR DESCRIPTION
## Summary

The proposal to keep the unusual note off event as input. Because the current implementation drops such note-offs and breaks the time of following events.

## How to Reproduce Issue

Note: I included the test in this PR.

1. Copy [a sample MIDI file](http://yasashiiorgel.jp/midi/hotaru.mid) (Auld Lang Syne) with midilib using the following code.
2. Play both of the original `hotaru.mid` and the output `output.mid`. So you'll find the obvious error.

```rb
require "midilib"

def read_midifile(infile)
    MIDI::Sequence.new().tap do |seq|
        File.open(infile, 'rb') { |file|
            seq.read(file)
        }
    end
end

def write_midifile(outfile, seq)
    File.open(outfile, 'wb') { |file|
        seq.write(file)
    }
end

# Download a midi file.
system "curl -O 'http://yasashiiorgel.jp/midi/hotaru.mid'"

# Just copy the SMF data as is using midilib.
write_midifile('output.mid', read_midifile('hotaru.mid'))
```

## Detail

The above sample MIDI file has unusual note-off events like this:

```
[From output of midi-dump https://g200kg.github.io/midi-dump/]

0000a0 00 4f 00                     +0 =      0 :  NoteOn  (ch:1  note:79 velo:0)
0000a3 00 4f 40                     +0 =      0 :  NoteOn  (ch:1  note:79 velo:64)
0000a6 58 3c 00                    +88 =     88 :  NoteOn  (ch:1  note:60 velo:0)
0000a9 00 3c 40                     +0 =     88 :  NoteOn  (ch:1  note:60 velo:64)
```

Why that? The MIDI is produced by a composer software for [DIY hand crank music boxes](https://www.youtube.com/results?search_query=hand+crank+DIY+music+box). To reproduce the instrument's damper behavior, any note-off events always appear just before the corresponding note-on.

As for the above four events, midilib drops the third note-off event because the corresponding note-on event is not found. Therefore the time of the forth note-on event breaks.


