### PR TITLE
Fix ordering and byte size of song position pointer data bytes

### DIFF
--- a/Credits
+++ b/Credits
@@ -102,3 +102,4 @@ Miika Alonen (@amiika on Github)
     Opened an issue (https://github.com/jimm/midilib/issues/24) which led to
     the addition of end of track meta events when reading and writing MIDI
     files.
+    Found and fixed a bug in SongPointer#data_as_bytes.

--- a/lib/midilib/event.rb
+++ b/lib/midilib/event.rb
@@ -299,8 +299,8 @@ module MIDI
     def data_as_bytes
       data = []
       data << @status
-      data << ((@pointer >> 8) & 0xff)
-      data << (@pointer & 0xff)
+      data << (@pointer & 0x7f)
+      data << ((@pointer >> 7) & 0x7f)
     end
 
     def to_s

--- a/test/test_event.rb
+++ b/test/test_event.rb
@@ -130,4 +130,16 @@ class EventTester < Test::Unit::TestCase
     assert_equal('foobar', e.data_as_str)
     assert_equal(foobar_as_array, e.data)
   end
+
+  def test_song_pointer
+    e = MIDI::SongPointer.new(1)
+    b = e.data_as_bytes
+    assert_equal(1, b[1])       # lsb, 7 bits
+    assert_equal(0, b[2])       # msb, 7 bits
+
+    e.pointer = (3 << 7) + 42
+    b = e.data_as_bytes
+    assert_equal(42, b[1])      # lsb, 7 bits
+    assert_equal(3, b[2])       # msb, 7 bits
+  end
 end


### PR DESCRIPTION
Before, SongPointer#data_as_bytes was using 8-bit bytes in big-endian order.  But the MIDI spec calls for two 7-bit bytes in little-endian order with LSB first, similar to the pitch bend message.

Related to https://github.com/arirusso/nibbler/pull/5

# References used
- https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message
- jack_midi_dump output from a hardware sequencer

# Before
Note that my program displays new messages at the top, while jack_midi_dump shows new messages at the bottom.

|jack_midi_dump|midilib|
|--------------|--------------|
|![jack_midi_dump song pointer](https://user-images.githubusercontent.com/5015814/216848650-e6c41328-e28e-4276-917e-ba352e230bb6.png)|bytes swapped, lsb exceeds 0x7f ![midilib song pointer broken](https://user-images.githubusercontent.com/5015814/216848692-19c4f906-6f4d-4fc7-b713-af258f49ed35.png) |

# After
|jack_midi_dump|midilib|
|------|------|
|![image](https://user-images.githubusercontent.com/5015814/216848857-7314dfcb-080c-47a3-93f5-0a2916425c3e.png)|![image](https://user-images.githubusercontent.com/5015814/216848868-afd4be8b-0650-4530-a30f-2058e1d7cd61.png)|

